### PR TITLE
Read in open pull request for configured repos

### DIFF
--- a/source/ServerConfiguration.ts
+++ b/source/ServerConfiguration.ts
@@ -1,6 +1,0 @@
-module Print {
-	export class ServerConfiguration {
-		name: string
-		secret: string
-	}
-}

--- a/source/configuration/ServerConfiguration.ts
+++ b/source/configuration/ServerConfiguration.ts
@@ -8,7 +8,14 @@ module Print {
 		organization: string;
 		secret: string;
 		static readConfigurationFile(file: string): ServerConfiguration[] {
-			return <ServerConfiguration[]>JSON.parse(fs.readFileSync(file, "utf-8"));
+			var result: ServerConfiguration[] = []
+			try {
+				result = <ServerConfiguration[]>JSON.parse(fs.readFileSync(file, "utf-8"));
+			} catch (Error) {
+				console.log("There was an error while reading the configuration file, unable to continue.\n" + Error.toString())
+				process.exit(1); // TODO: Recover or crash and burn?
+			}
+			return result;
 		}
 	}
 }

--- a/source/configuration/ServerConfiguration.ts
+++ b/source/configuration/ServerConfiguration.ts
@@ -5,6 +5,7 @@ var fs = require("fs")
 module Print {
 	export class ServerConfiguration {
 		name: string;
+		organization: string;
 		secret: string;
 		static readConfigurationFile(file: string): ServerConfiguration[] {
 			return <ServerConfiguration[]>JSON.parse(fs.readFileSync(file, "utf-8"));

--- a/source/configuration/ServerConfiguration.ts
+++ b/source/configuration/ServerConfiguration.ts
@@ -1,0 +1,13 @@
+/// <reference path="../../typings/node/node" />
+
+var fs = require("fs")
+
+module Print {
+	export class ServerConfiguration {
+		name: string;
+		secret: string;
+		static readConfigurationFile(file: string): ServerConfiguration[] {
+			return <ServerConfiguration[]>JSON.parse(fs.readFileSync(file, "utf-8"));
+		}
+	}
+}

--- a/source/github/Head.ts
+++ b/source/github/Head.ts
@@ -1,0 +1,12 @@
+/// <reference path="User" />
+/// <reference path="Repository" />
+
+module Print.Github {
+	export class Head {
+		label: string;
+		ref: string;
+		sha: string;
+		user: User
+		repo: Repository
+	}
+}

--- a/source/github/PullRequest.ts
+++ b/source/github/PullRequest.ts
@@ -1,0 +1,20 @@
+/// <reference path="User" />
+
+module Print.Github {
+	export class PullRequest {
+		html_url: string;
+		diff_url: string;
+		number: number;
+		state: string;
+		title: string;
+		user: User;
+		body: string;
+		created_at: string;
+		updated_at: string;
+		merged: boolean;
+		commits: number;
+		additions: number;
+		deletions: number;
+		changed_files: number;
+	}
+}

--- a/source/github/PullRequest.ts
+++ b/source/github/PullRequest.ts
@@ -2,6 +2,8 @@
 
 module Print.Github {
 	export class PullRequest {
+		id: string;
+		url: string;
 		html_url: string;
 		diff_url: string;
 		number: number;

--- a/source/github/Repository.ts
+++ b/source/github/Repository.ts
@@ -7,5 +7,8 @@ module Print.Github {
 		full_name: string;
 		owner: Owner;
 		private: boolean;
+		fork: boolean;
+		url: string;
+		pulls_url: string;
 	}
 }

--- a/source/github/Repository.ts
+++ b/source/github/Repository.ts
@@ -2,6 +2,7 @@
 
 module Print.Github {
 	export class Repository {
+		id: string;
 		name: string;
 		full_name: string;
 		owner: Owner;

--- a/source/github/User.ts
+++ b/source/github/User.ts
@@ -1,0 +1,5 @@
+module Print.Github {
+	export class User {
+		login: string;
+	}
+}

--- a/source/github/api/PullRequest.ts
+++ b/source/github/api/PullRequest.ts
@@ -1,0 +1,37 @@
+/// <reference path="../../../typings/node/node" />
+/// <reference path="../PullRequest" />
+/// <reference path="../../server/PullRequest" />
+
+var https = require("https")
+
+module Print.Github.Api {
+	export class PullRequest {
+		//
+		// TODO: Use Github api instead of hardcoded urls
+		//
+		static queryOpenPullRequests(organization: string, repository: string, onFinishedCallback: (result: Print.Server.PullRequest[]) => void) {
+			var buffer: string = ""
+			var options = {
+				hostname: "api.github.com",
+				path: "/repos/" + organization + "/" + repository + "/pulls?state=open",
+				method: "GET",
+				headers: { "User-Agent": "print" }
+			};
+			https.request(options, (response: any) => {
+				response.on("data", (chunk: string) => {
+					buffer += chunk
+				});
+				response.on("error", (error: any) => {
+					console.log("ERROR:", error.toString());
+				});
+				response.on("end", () => {
+					var result: Server.PullRequest[] = [];
+					(<Github.PullRequest[]>JSON.parse(buffer)).forEach(request => {
+						result.push(new Server.PullRequest(request));
+					});
+					onFinishedCallback(result);
+				});
+			}).end();
+		}
+	}
+}

--- a/source/github/api/Url.ts
+++ b/source/github/api/Url.ts
@@ -1,0 +1,47 @@
+/// <reference path="../../../typings/node/node" />
+
+var https = require("https");
+
+module Print.Github.Api {
+	export abstract class Url {
+		organization_repositories_url: string;
+		static queryApiUrl() {
+			// TODO
+		}
+	}
+}
+
+/*
+api.github.com
+{
+  "current_user_url": "https://api.github.com/user",
+  "current_user_authorizations_html_url": "https://github.com/settings/connections/applications{/client_id}",
+  "authorizations_url": "https://api.github.com/authorizations",
+  "code_search_url": "https://api.github.com/search/code?q={query}{&page,per_page,sort,order}",
+  "emails_url": "https://api.github.com/user/emails",
+  "emojis_url": "https://api.github.com/emojis",
+  "events_url": "https://api.github.com/events",
+  "feeds_url": "https://api.github.com/feeds",
+  "followers_url": "https://api.github.com/user/followers",
+  "following_url": "https://api.github.com/user/following{/target}",
+  "gists_url": "https://api.github.com/gists{/gist_id}",
+  "hub_url": "https://api.github.com/hub",
+  "issue_search_url": "https://api.github.com/search/issues?q={query}{&page,per_page,sort,order}",
+  "issues_url": "https://api.github.com/issues",
+  "keys_url": "https://api.github.com/user/keys",
+  "notifications_url": "https://api.github.com/notifications",
+  "organization_repositories_url": "https://api.github.com/orgs/{org}/repos{?type,page,per_page,sort}",
+  "organization_url": "https://api.github.com/orgs/{org}",
+  "public_gists_url": "https://api.github.com/gists/public",
+  "rate_limit_url": "https://api.github.com/rate_limit",
+  "repository_url": "https://api.github.com/repos/{owner}/{repo}",
+  "repository_search_url": "https://api.github.com/search/repositories?q={query}{&page,per_page,sort,order}",
+  "current_user_repositories_url": "https://api.github.com/user/repos{?type,page,per_page,sort}",
+  "starred_url": "https://api.github.com/user/starred{/owner}{/repo}",
+  "starred_gists_url": "https://api.github.com/gists/starred",
+  "team_url": "https://api.github.com/teams",
+  "user_url": "https://api.github.com/users/{user}",
+  "user_organizations_url": "https://api.github.com/user/orgs",
+  "user_repositories_url": "https://api.github.com/users/{user}/repos{?type,page,per_page,sort}",
+  "user_search_url": "https://api.github.com/search/users?q={query}{&page,per_page,sort,order}"
+}*/

--- a/source/github/events/PullRequestEvent.ts
+++ b/source/github/events/PullRequestEvent.ts
@@ -5,12 +5,12 @@ module Print.Github.Events {
 	export class PullRequestEvent {
 		/*
 		The action that was performed.
-		Can be one of “assigned”, “unassigned”, “labeled”, “unlabeled”, “opened”, “closed”, or “reopened”, or “synchronize”.
+		Action can be one of “assigned”, “unassigned”, “labeled”, “unlabeled”, “opened”, “closed”, or “reopened”, or “synchronize”.
 		If the action is “closed” and the merged key is false, the pull request was closed with unmerged commits.
 		If the action is “closed” and the merged key is true, the pull request was merged. */
 		action: string;
 		number: number;
-		pull_request: Print.Github.PullRequest;
+		pull_request: PullRequest;
 		repository: Repository;
 		//sender: Sender
 	}

--- a/source/github/events/PullRequestEvent.ts
+++ b/source/github/events/PullRequestEvent.ts
@@ -1,0 +1,17 @@
+/// <reference path="../PullRequest" />
+/// <reference path="../Repository" />
+
+module Print.Github.Events {
+	export class PullRequestEvent {
+		/*
+		The action that was performed.
+		Can be one of “assigned”, “unassigned”, “labeled”, “unlabeled”, “opened”, “closed”, or “reopened”, or “synchronize”.
+		If the action is “closed” and the merged key is false, the pull request was closed with unmerged commits.
+		If the action is “closed” and the merged key is true, the pull request was merged. */
+		action: string;
+		number: number;
+		pull_request: Print.Github.PullRequest;
+		repository: Repository;
+		//sender: Sender
+	}
+}

--- a/source/github/events/PushEvent.ts
+++ b/source/github/events/PushEvent.ts
@@ -1,8 +1,8 @@
 /// <reference path="../Commit" />
 /// <reference path="../Repository" />
 
-module Print.Github {
-	export class Push  {
+module Print.Github.Events {
+	export class PushEvent  {
 		compare: string;
 		head_commit: Commit;
 		repository: Repository;

--- a/source/print.ts
+++ b/source/print.ts
@@ -1,14 +1,11 @@
 /// <reference path="server/LocalServer" />
-/// <reference path="github/events/Push" />
-
-var fs = require("fs")
 
 module Print {
 	export class Program {
 		private server: Server.LocalServer
 		constructor() {
 			this.registerKeyEvents();
-			this.server = new Server.LocalServer(48085);
+			this.server = new Server.LocalServer("config.json");
 			this.server.start();
 		}
 		registerKeyEvents() {

--- a/source/server/LocalServer.ts
+++ b/source/server/LocalServer.ts
@@ -34,22 +34,18 @@ module Print.Server {
 			var name = url.substr(7, url.length - 7);
 			switch (<string>request.method) {
 				case "POST":
-					if (this.pullRequestQueues.some(queue => { return queue.process(name, request); })) {
-						request.on("end", () => {
-							this.sendResponse(response, 200, "OK");
-						});
-					} else {
-						this.sendResponse(response, 404, "Not found");
+					if (!this.pullRequestQueues.some(queue => { return queue.process(name, request, response); })) {
+						LocalServer.sendResponse(response, 404, "Not found");
 					}
 					break;
 				case "GET":
 					console.log("Received a GET request - responding with [400: Bad request]");
 				default:
-					this.sendResponse(response, 400, "Bad request");
+					LocalServer.sendResponse(response, 400, "Bad request");
 					break;
 			}
 		}
-		private sendResponse(responseObject: any, code: number, message: string) {
+		static sendResponse(responseObject: any, code: number, message: string) {
 			responseObject.writeHead(code, message, { "Content-Type": "text/plain" });
 			responseObject.end();
 		}

--- a/source/server/LocalServer.ts
+++ b/source/server/LocalServer.ts
@@ -26,7 +26,7 @@ module Print.Server {
 		}
 		stop() {
 			this.server.close(() => {
-				console.log("print server closed");
+				console.log("server closed");
 			});
 		}
 		private requestCallback(request: any, response: any) {

--- a/source/server/PullRequest.ts
+++ b/source/server/PullRequest.ts
@@ -1,11 +1,48 @@
 /// <reference path="../../typings/node/node.d.ts" />
 /// <reference path="../configuration/ServerConfiguration" />
-
 /// <reference path="../github/events/PullRequestEvent" />
 
 module Print.Server {
 	export class PullRequest {
-		constructor(private number: number, event: Github.Events.PullRequestEvent) {
+		private id: string;
+		private number: number;
+		private title: string;
+		private description: string;
+		private createdAt: string;
+		private updatedAt: string;
+		private commitCount: number;
+		private url: string;
+		private diffUrl: string;
+		constructor(request: Github.PullRequest) {
+			this.readPullRequestData(request)
+		}
+		getId(): string { return this.id; }
+		getNumber(): number { return this.number; }
+		getTitle(): string { return this.title; }
+		getCreatedAt(): Date { return new Date(this.createdAt); }
+		getUpdatedAt(): Date { return new Date(this.createdAt); }
+		getCommitCount(): number { return this.commitCount; }
+		getUrl(): string { return this.url; }
+		getDiffUrl(): string { return this.diffUrl; }
+		tryUpdate(request: Github.PullRequest): boolean {
+			var result = false;
+			console.log("attempting to update pull request")
+			if (request.created_at != request.updated_at) {
+				this.readPullRequestData(request);
+				console.log("pull request updated")
+				result = true;
+			}
+			return result;
+		}
+		private readPullRequestData(pullRequest: Github.PullRequest) {
+			this.id = pullRequest.id;
+			this.title = pullRequest.title;
+			this.description = pullRequest.body;
+			this.createdAt = pullRequest.created_at;
+			this.updatedAt = pullRequest.updated_at;
+			this.commitCount = pullRequest.commits;
+			this.url = pullRequest.html_url;
+			this.diffUrl = pullRequest.diff_url;
 		}
 	}
 }

--- a/source/server/PullRequest.ts
+++ b/source/server/PullRequest.ts
@@ -1,0 +1,11 @@
+/// <reference path="../../typings/node/node.d.ts" />
+/// <reference path="../configuration/ServerConfiguration" />
+
+/// <reference path="../github/events/PullRequestEvent" />
+
+module Print.Server {
+	export class PullRequest {
+		constructor(private number: number, event: Github.Events.PullRequestEvent) {
+		}
+	}
+}

--- a/source/server/PullRequestQueue.ts
+++ b/source/server/PullRequestQueue.ts
@@ -1,0 +1,27 @@
+/// <reference path="../../typings/node/node.d.ts" />
+/// <reference path="../configuration/ServerConfiguration" />
+/// <reference path="PullRequest" />
+/// <reference path="../github/events/PullRequestEvent" />
+
+module Print.Server {
+	export class PullRequestQueue {
+		private request: PullRequest[] = [];
+		constructor(private name: string) {
+		}
+		process(name: string, request: any): boolean {
+			var result: boolean;
+			//
+			// TODO: Do we check the header if this is in fact a pull request event?
+			//
+			if (result = (name == this.name)) {
+				request.on("data", (payload: any) => {
+					// here we check if the PR exists in our list
+					// event goes into PullRequest where it is sorted out and processed to find out if there was a change
+					var event = <Print.Github.Events.PullRequestEvent>JSON.parse(payload);
+					console.log(event.pull_request.number);
+				})
+			}
+			return result;
+		}
+	}
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,15 +10,18 @@
 		"sourceRoot": "../source"
 	},
 	"files": [
-		"source/github/events/Push.ts",
-		
+		"source/configuration/ServerConfiguration.ts",
+		"source/github/events/PullRequestEvent.ts",
+		"source/github/events/PushEvent.ts",
 		"source/github/Author.ts",
 		"source/github/Commit.ts",
 		"source/github/Owner.ts",
+		"source/github/PullRequest.ts",
 		"source/github/Repository.ts",
-		
+		"source/github/User.ts",
+		"source/server/PullRequest.ts",
+		"source/server/PullRequestQueue.ts",
 		"source/server/LocalServer.ts",
-		
 		"source/print.ts"
 	]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,10 +11,13 @@
 	},
 	"files": [
 		"source/configuration/ServerConfiguration.ts",
+		"source/github/api/PullRequest.ts",
+		"source/github/api/Url.ts",
 		"source/github/events/PullRequestEvent.ts",
 		"source/github/events/PushEvent.ts",
 		"source/github/Author.ts",
 		"source/github/Commit.ts",
+		"source/github/Head.ts",
 		"source/github/Owner.ts",
 		"source/github/PullRequest.ts",
 		"source/github/Repository.ts",


### PR DESCRIPTION
- Print now reads in open PRs for the configured repos upon launch
- Print now listens for PR events for the configured repos and updates if it receives one

**Issues**
- The API urls are still hardcoded.
- I'm not too sure the asynchronous calls are 100% stable yet, I've fixed a few bugs and it _seems_ to work.
- We definitely need to review the asynchronous architecture
