### PR TITLE
Global replace

### DIFF
--- a/source/childprocess/Taskmaster.ts
+++ b/source/childprocess/Taskmaster.ts
@@ -89,7 +89,7 @@ module Print.Childprocess {
             var args: string[] = [];
             var path: string = repositoryPath;
             if (action.args)
-                args = action.args.replace("~", process.env["HOME"]).split(",");
+                args = action.args.replace(/~/g, process.env["HOME"]).split(",");
             if (action.path)
                 path += "/" + action.path;
             var fallback: Job;


### PR DESCRIPTION
So this was (one of our) problems. 

I had a command where two arguments contained `~`, and typescript/javascript `replace` defaults to only replace the first instance.